### PR TITLE
Localize randomness

### DIFF
--- a/app/miniFAVOR.f90
+++ b/app/miniFAVOR.f90
@@ -18,7 +18,7 @@
     use calc_RTndt
     use calc_K
     use calc_cpi
-    use randomness_m, only: random_samples_t, get_samples
+    use randomness_m, only: random_samples_t
 
     implicit none
 
@@ -77,7 +77,7 @@
 
     ! This cannot be parallelized or reordered without the results changing
     do i = 1, nsim
-      samples(i) = get_samples()
+      call samples(i)%define()
     end do
 
     !Start looping over number of simulations

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,4 +4,5 @@ add_library(minifav
   Calc_RTndt.f90
   Commons.f90
   I_O.f90
+  randomness_m.f90
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,4 +5,5 @@ add_library(minifav
   Commons.f90
   I_O.f90
   randomness_m.f90
+  randomness_s.f90
 )

--- a/src/Calc_RTndt.f90
+++ b/src/Calc_RTndt.f90
@@ -1,40 +1,39 @@
 module calc_RTndt
-    
+
 implicit none
-    
+
     contains
-        
+
     !RTndt_x calculation
-    function RTndt(a, CF, fsurf, RTndt0)
-            
+    function RTndt(a, CF, fsurf, RTndt0, phi)
+
         !Variables
-        real :: RTndt, D_RTepi, D_RTndt, phi, f
-        real, intent(in) :: a, CF, fsurf, RTndt0
-            
+        real :: RTndt, D_RTepi, D_RTndt, f
+        real, intent(in) :: a, CF, fsurf, RTndt0, phi
+
         !Calculate D_RTepi
-        call RANDOM_NUMBER(phi)
         D_RTepi = -29.5+78.0*(-log(1-phi))**(1/1.73)
-            
+
         !Calculate D_RTndt
         f = fsurf*exp(-0.24*a)
         D_RTndt = CF*f**(0.28-0.10*log10(f))
-            
+
         !Calculate the RTndt
         RTndt = RTndt0 + D_RTepi + D_RTndt
-            
+
     end function RTndt
-        
+
     !This function calculates the weld chemistry factor given the copper and nickel contents
     function CF(Cu, Ni)
-            
+
         use constants_h, only: CF_weld
-            
+
         !Variables
         real :: CF
         real, intent(in) :: Cu, Ni
         integer :: Cu_int, Ni_int
         real :: CF_1, CF_2
-            
+
         !Calculate indexes for copper interpolation:
         !  multiply the Cu-% by 100 and take the integer truncation to find interpolation bounds
         !  truncate interpolation between 0% and 0.40%
@@ -44,7 +43,7 @@ implicit none
         else if (Cu_int > 40) then
             Cu_int = 40
         end if
-            
+
         !Calculate indexes for nickel interpolation:
         !  multiply the Ni-% by 100 and take the integer truncation to find interpolation bounds
         !  truncate interpolation between 0% and 1.20%
@@ -56,7 +55,7 @@ implicit none
         end if
         !Nickel contents in CF_weld are at intervals of 0.20% nickel
         Ni_int = int(Ni_int/20)+1
-            
+
         !Bi-linear interpolation
         if (Cu <= 0.0 .or. Cu >= 0.40) then !only interpolate on nickel
             select case (Ni_int)
@@ -81,30 +80,29 @@ implicit none
             CF = CF_1 + (Ni-0.2*(Ni_int-1))/0.2 * (CF_2-CF_1)
             end select
         end if
-            
+
     end function CF
-        
+
     !This subroutine samples the copper and nickel contents based on the nominal value
     !and the standard deviation
-    subroutine sample_chem(Cu_ave, Ni_ave, Cu_sig, Ni_sig, Cu_local, Ni_local)
-            
+    subroutine sample_chem(Cu_ave, Ni_ave, Cu_sig, Ni_sig, Cu_local, Ni_local, &
+          Cu_sig_local_sample, Cu_local_sample, Ni_local_sample)
+
         !Variables
         real, intent(in) :: Cu_ave, Ni_ave, Cu_sig, Ni_sig
         real, intent(out) :: Cu_local, Ni_local
-        real :: u, Cu_bar, Cu_sig_star, Cu_sig_local
-            
+        real, intent(in) :: Cu_sig_local_sample, Cu_local_sample, Ni_local_sample
+        real :: Cu_bar, Cu_sig_star, Cu_sig_local
+
         !Sample local copper content based on weld copper sampling procedure
         Cu_bar = Cu_ave * Cu_sig
         Cu_sig_star = min(0.0718*Cu_ave, 0.0185)
-        call RANDOM_NUMBER(u)
-        Cu_sig_local = Cu_bar + Cu_sig_star*sqrt(2.0)*erfc(2*u-1)
-        call RANDOM_NUMBER(u)
-        Cu_local = Cu_ave + Cu_sig_local*sqrt(2.0)*erfc(2*u-1)
-            
+        Cu_sig_local = Cu_bar + Cu_sig_star*sqrt(2.0)*erfc(2*Cu_sig_local_sample-1)
+        Cu_local = Cu_ave + Cu_sig_local*sqrt(2.0)*erfc(2*Cu_local_sample-1)
+
         !Sample local nickel content based on weld nickel heat 34B009 & W5214 procedure
-        call RANDOM_NUMBER(u)
-        Ni_local = Ni_ave + Ni_sig*sqrt(2.0)*erfc(2*u-1)
-            
+        Ni_local = Ni_ave + Ni_sig*sqrt(2.0)*erfc(2*Ni_local_sample-1)
+
     end subroutine sample_chem
-        
+
 end module calc_RTndt

--- a/src/randomness_m.f90
+++ b/src/randomness_m.f90
@@ -1,22 +1,22 @@
 module randomness_m
   implicit none
   private
-  public :: random_samples_t, get_samples
+  public :: random_samples_t
 
   type :: random_samples_t
     real :: Cu_sig_local
     real :: Cu_local
     real :: Ni_local
     real :: phi
+  contains
+    procedure :: define
   end type
-contains
-  function get_samples() result(samples)
-    type(random_samples_t) :: samples
 
-    ! These must be called in this order or the results will change
-    call random_number(samples%Cu_sig_local)
-    call random_number(samples%Cu_local)
-    call random_number(samples%Ni_local)
-    call random_number(samples%phi)
-  end function
+  interface
+    module subroutine define(self)
+      implicit none
+      class(random_samples_t), intent(out) :: self
+    end subroutine
+  end interface
+
 end module

--- a/src/randomness_m.f90
+++ b/src/randomness_m.f90
@@ -1,0 +1,22 @@
+module randomness_m
+  implicit none
+  private
+  public :: random_samples_t, get_samples
+
+  type :: random_samples_t
+    real :: Cu_sig_local
+    real :: Cu_local
+    real :: Ni_local
+    real :: phi
+  end type
+contains
+  function get_samples() result(samples)
+    type(random_samples_t) :: samples
+
+    ! These must be called in this order or the results will change
+    call random_number(samples%Cu_sig_local)
+    call random_number(samples%Cu_local)
+    call random_number(samples%Ni_local)
+    call random_number(samples%phi)
+  end function
+end module

--- a/src/randomness_s.f90
+++ b/src/randomness_s.f90
@@ -1,0 +1,12 @@
+submodule(randomness_m) randomness_s
+  implicit none
+
+contains
+  module procedure define
+    ! These must be called in this order or the results will change
+    call random_number(self%Cu_sig_local)
+    call random_number(self%Cu_local)
+    call random_number(self%Ni_local)
+    call random_number(self%phi)
+  end procedure
+end submodule


### PR DESCRIPTION
Take all of the calls to random number out of the inner loops without changing the order in which the random numbers are used. This will allow us to make the inner loops parallel without changing the answers. Fix #14