### PR TITLE
Only deploy the documentation on the develop branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,6 +40,7 @@ jobs:
         ford miniFAVOR-FORD-file.md
 
     - name: Deploy documentation to gh-pages branch
+      if: ${{ github.ref == 'refs/heads/develop' }}
       uses: JamesIves/github-pages-deploy-action@3.7.1
       with:
         BRANCH: gh-pages


### PR DESCRIPTION
Modify the CI script so that the documentation only gets deployed for the develop branch.

Fix #15