### PR TITLE
Refactor main: split arrays, remove initializations, use elemental, clarify dependencies

### DIFF
--- a/app/miniFAVOR.f90
+++ b/app/miniFAVOR.f90
@@ -14,10 +14,10 @@
 
     program miniFAVOR
 
-    use I_O
-    use calc_RTndt
-    use calc_K
-    use calc_cpi
+    use I_O, only : read_In, write_Out
+    use calc_RTndt, only : RTndt, CF, sample_chem
+    use calc_K, only : Ki_t
+    use calc_cpi, only : cpi_t
     use randomness_m, only: random_samples_t
 
     implicit none

--- a/app/miniFAVOR.f90
+++ b/app/miniFAVOR.f90
@@ -39,10 +39,14 @@
     real :: Cu_ave, Ni_ave, Cu_sig, Ni_sig, fsurf, RTndt0
 
     ! Outputs
-    real, dimension(:), allocatable :: K_hist
-    real, dimension(:,:), allocatable :: Chemistry
+    real, allocatable :: K_hist(:)
+    real, allocatable :: Chemistry_factor(:)
+    real, allocatable :: R_Tndt(:)
+    real, allocatable :: CPI(:)
+    real, allocatable :: CPI_avg(:)
+    real, dimension(:,:), allocatable :: Chemistry_content
     real, dimension(:,:), allocatable :: cpi_hist
-    real, dimension(:,:), allocatable :: CPI_results
+    integer, parameter :: nmaterials=2
 
     ! Body of miniFAVOR
 
@@ -58,10 +62,10 @@
         a, b, nsim, ntime, details, Cu_ave, Ni_ave, Cu_sig, Ni_sig, fsurf, RTndt0, stress, temp)
 
     !Allocate output arrays
-    allocate(Chemistry(nsim,3))
+    allocate(Chemistry_content(nsim, nmaterials))
+    allocate(Chemistry_factor(nsim))
     allocate(cpi_hist(nsim, ntime))
-    allocate(CPI_results(nsim,3))
-    allocate(samples(nsim))
+    allocate(R_Tndt(nsim), CPI(nsim), CPI_avg(nsim), samples(nsim))
 
     !Calculate applied stress intensity factor (SIF)
     K_hist = Ki_t(a, b, stress)
@@ -74,31 +78,31 @@
     !Start looping over number of simulations
     Vessel_loop: do i = 1, nsim
 
-        !Sample chemistry: Chemistry(i,1) is Cu content, Chemistry(i,2) is Ni content
-        call sample_chem(Cu_ave, Ni_ave, Cu_sig, Ni_sig, Chemistry(i,1), Chemistry(i,2), samples(i))
+        !Sample chemistry: Chemistry_content(i,1) is Cu content, Chemistry_content(i,2) is Ni content
+        call sample_chem(Cu_ave, Ni_ave, Cu_sig, Ni_sig, Chemistry_content(i,1), Chemistry_content(i,2), samples(i))
 
-        !Calculate chemistry factor: Chemistry(i,3) is chemistry factor
-        Chemistry(i,3) = CF(Chemistry(i,1), Chemistry(i,2))
+        !Calculate chemistry factor: Chemistry_factor(i) is chemistry factor
+        Chemistry_factor(i) = CF(Chemistry_content(i,1), Chemistry_content(i,2))
 
         !Calculate RTndt for this vessel trial: CPI_results(i,1) is RTndt
-        CPI_results(i,1) = RTndt(a, Chemistry(i,3), fsurf, RTndt0, samples(i)%phi())
+        R_Tndt(i) = RTndt(a, Chemistry_factor(i), fsurf, RTndt0, samples(i)%phi())
 
         !Start time loop
         Time_loop: do j = 1, ntime
             !Calculate instantaneous cpi(t)
-            cpi_hist(i,j) = cpi_t(K_hist(j), CPI_results(i,1), temp(j))
+            cpi_hist(i,j) = cpi_t(K_hist(j), R_Tndt(i), temp(j))
         end do Time_loop
 
         !Calculate CPI for vessel 'i'
-        CPI_results(i,2) = maxval(cpi_hist(i,:))
+        CPI(i) = maxval(cpi_hist(i,:))
 
         !Calculate moving average CPI for trials executed so far
-        CPI_results(i,3) = sum(CPI_results(1:i,2))/i
+        CPI_avg(i) = sum(CPI(1:i))/i
 
     end do Vessel_loop
 
     call write_OUT(fn_IN, n_OUT, n_DAT, &
         a, b, nsim, ntime, details, Cu_ave, Ni_ave, Cu_sig, Ni_sig, fsurf, RTndt0, &
-        CPI_results, K_hist, Chemistry)
+        R_Tndt, CPI, CPI_avg, K_hist, Chemistry_content, Chemistry_factor)
 
     end program miniFAVOR

--- a/app/miniFAVOR.f90
+++ b/app/miniFAVOR.f90
@@ -63,11 +63,6 @@
     allocate(CPI_results(nsim,3))
     allocate(samples(nsim))
 
-    !Initialize output arrays
-    Chemistry = 0.0
-    cpi_hist = 0.0
-    CPI_results = 0.0
-
     !Calculate applied stress intensity factor (SIF)
     K_hist = Ki_t(a, b, stress)
 
@@ -98,7 +93,7 @@
         CPI_results(i,2) = maxval(cpi_hist(i,:))
 
         !Calculate moving average CPI for trials executed so far
-        CPI_results(i,3) = sum(CPI_results(:,2))/i
+        CPI_results(i,3) = sum(CPI_results(1:i,2))/i
 
     end do Vessel_loop
 

--- a/app/miniFAVOR.f90
+++ b/app/miniFAVOR.f90
@@ -58,22 +58,18 @@
         a, b, nsim, ntime, details, Cu_ave, Ni_ave, Cu_sig, Ni_sig, fsurf, RTndt0, stress, temp)
 
     !Allocate output arrays
-    allocate(K_hist(ntime))
     allocate(Chemistry(nsim,3))
     allocate(cpi_hist(nsim, ntime))
     allocate(CPI_results(nsim,3))
     allocate(samples(nsim))
 
     !Initialize output arrays
-    K_hist =  0.0
     Chemistry = 0.0
     cpi_hist = 0.0
     CPI_results = 0.0
 
     !Calculate applied stress intensity factor (SIF)
-    SIF_loop: do j = 1, ntime
-        K_hist(j) = Ki_t(a, b, stress(j))
-    end do SIF_loop
+    K_hist = Ki_t(a, b, stress)
 
     ! This cannot be parallelized or reordered without the results changing
     do i = 1, nsim

--- a/src/Calc_K.f90
+++ b/src/Calc_K.f90
@@ -1,22 +1,22 @@
 module calc_K
-    
+
 implicit none
-    
+
     contains
-        
+
     !Function to calculate K(t)
-    function Ki_t(a, b, stress)
-            
+    elemental function Ki_t(a, b, stress)
+
         use constants_h, only: Pi
-            
+
         !Variables
         real :: Ki_t
         real, intent(in) :: a, b, stress
-            
+
         !Calculate Ki_t
         Ki_t = stress*sqrt(Pi*a)*   &
             (1.122-0.231*(a/b)+10.55*(a/b)**2-21.71*(a/b)**3+30.382*(a/b)**4)
-            
+
     end function Ki_t
 
 end module calc_K

--- a/src/I_O.f90
+++ b/src/I_O.f90
@@ -61,7 +61,7 @@ implicit none
 
     subroutine write_OUT(fn_IN, n_OUT, n_DAT, &
         a, b, nsim, ntime, details, Cu_ave, Ni_ave, Cu_sig, Ni_sig, fsurf, RTndt0, &
-        CPI_results, K_hist, Chemistry)
+        R_Tndt, CPI, CPI_avg, K_hist, Chemistry_content, Chemistry_factor)
 
         !Variables
         character(len=64), intent(in) :: fn_IN
@@ -69,7 +69,10 @@ implicit none
         real, intent(in) :: a, b, Cu_ave, Ni_ave, Cu_sig, Ni_sig, fsurf, RTndt0
         integer, intent(in) :: nsim, ntime
         logical, intent(in) :: details
-        real, intent(in) :: CPI_results(:,:), K_hist(:), Chemistry(:,:)
+        real, intent(in) :: K_hist(:), Chemistry_content(:,:), Chemistry_factor(:)
+        real, intent(in) :: R_Tndt(:)
+        real, intent(in) :: CPI(:)
+        real, intent(in) :: CPI_avg(:)
 
         character(len=64) :: fn_OUT, fn_DAT
         integer :: i
@@ -91,13 +94,13 @@ implicit none
         write (n_OUT, '(a25,f10.3,a)') 'ID Surface Fluence: ', fsurf, ' n/cm^2'
         write (n_OUT, '(a25,f10.3,a)') 'Unirradiated RTndt: ', RTndt0, ' degF'
         write (n_OUT, '(a)') '/Results/'
-        write (n_OUT, '(a25,f10.3)') 'Final CPI: ', CPI_results(nsim,3)
+        write (n_OUT, '(a25,f10.3)') 'Final CPI: ', CPI_avg(nsim)
         write (n_OUT, '(a25,f10.3,a)') 'Minimum crack tip RTndt: ', &
-            minval(CPI_results(:,1)), ' degF'
+            minval(R_Tndt), ' degF'
         write (n_OUT, '(a25,f10.3,a)') 'Maximum crack tip  RTndt: ', &
-            maxval(CPI_results(:,1)), ' degF'
+            maxval(R_Tndt), ' degF'
         write (n_OUT, '(a25,f10.3,a)') 'Average crack tip RTndt: ', &
-            sum(CPI_results(:,1))/nsim, ' degF'
+            sum(R_Tndt)/nsim, ' degF'
 
         !Write out detailed output to data file
         if (details) then
@@ -111,12 +114,12 @@ implicit none
             write (n_DAT, '(a)') '/Chemistry Results'
             write (n_DAT, '(a)') 'Cu content (%),  Ni Content (%), Chemistry Factor CF'
             write_chem: do  i = 1, nsim
-                write (n_DAT, '(3f10.3)') Chemistry(i,1), Chemistry(i,2), Chemistry(i,3)
+                write (n_DAT, '(3f10.3)') Chemistry_content(i,1), Chemistry_content(i,2), Chemistry_factor(i)
             end do write_chem
             write (n_DAT, '(a)') '/Vessel CPI data'
             write (n_DAT, '(a)') 'Vessel RTndt (degF),  Vessel CPI, Cumulative Average CPI'
             write_CPI: do  i = 1, nsim
-                write (n_DAT, '(3f10.3)') CPI_results(i,1), CPI_results(i,2), CPI_results(i,3)
+                write (n_DAT, '(3f10.3)') R_Tndt(i), CPI(i), CPI_avg(i)
             end do write_CPI
         end if
 


### PR DESCRIPTION
* Fix #31: split arrays
* Fix #30: remove zero-initializations
* Fix #29: make Ki_t elemental
* Fix #33: clarify internal dependencies and avoid name-space pollution