### PR TITLE
refac: gather random number generator calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,19 @@ if(HAVE_ERROR_STOP_IN_PURE)
   add_definitions(-DHAVE_ERROR_STOP_IN_PURE)
 endif()
 
+check_fortran_source_compiles("
+  program main
+  integer i
+  call co_sum(i)
+  end program
+"
+  HAVE_COLLECTIVE_SUBROUTINES
+  SRC_EXT ".f90"
+  )
+if(NOT HAVE_COLLECTIVE_SUBROUTINES)
+  add_definitions(-DCOMPILER_LACKS_COLLECTIVE_SUBROUTINES)
+endif()
+
 foreach(directory app src tests)
   add_subdirectory("${directory}")
 endforeach()

--- a/app/miniFAVOR.f90
+++ b/app/miniFAVOR.f90
@@ -28,7 +28,7 @@
     integer, parameter :: n_ECHO = n_IN + 1
     integer, parameter :: n_OUT = n_IN + 2
     integer, parameter :: n_DAT = n_IN + 3
-    integer :: i, j, num_seeds
+    integer :: i, j
     type(random_samples_t), allocatable :: samples(:)
 
     ! Inputs
@@ -51,9 +51,6 @@
     ! Body of miniFAVOR
 
     !Get input file name
-    call random_seed(size=num_seeds)
-    call random_seed(put=[(i, i=1, num_seeds)])
-
     print *, 'Input file name:'
     read (*,'(a)') fn_IN
 

--- a/src/random_samples_s.f90
+++ b/src/random_samples_s.f90
@@ -5,11 +5,23 @@ submodule(randomness_m) randomness_s
 contains
 
   module procedure define
+    logical, save :: first_call=.true.
+
+    if (first_call) then
+      first_call=.false.
+      block
+        integer i, num_seeds
+        call random_seed(size=num_seeds)
+        call random_seed(put=[(i, i=1, num_seeds)])
+      end block
+    end if
+
     ! These must be called in this order or the results will change
     call random_number(self%Cu_sig_local_)
     call random_number(self%Cu_local_)
     call random_number(self%Ni_local_)
     call random_number(self%phi_)
+
     call self%mark_as_defined
   end procedure
 


### PR DESCRIPTION
All code related to the pseudorandom number generator is now
abstracted away from the main program and encapsulated in the
random_sample_t define type-bound procedure.