### PR TITLE
Convert sample_chem subroutine to pure function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,19 @@ if(HAVE_ERROR_STOP_IN_PURE)
   add_definitions(-DHAVE_ERROR_STOP_IN_PURE)
 endif()
 
+check_fortran_source_compiles("
+  program main
+  integer i
+  call co_sum(i)
+  end program
+"
+  HAVE_COLLECTIVE_SUBROUTINES
+  SRC_EXT ".f90"
+  )
+if(NOT HAVE_COLLECTIVE_SUBROUTINES)
+  add_definitions(-DCOMPILER_LACKS_COLLECTIVE_SUBROUTINES)
+endif()
+
 foreach(directory app src tests)
   add_subdirectory("${directory}")
 endforeach()

--- a/app/miniFAVOR.f90
+++ b/app/miniFAVOR.f90
@@ -28,7 +28,7 @@
     integer, parameter :: n_ECHO = n_IN + 1
     integer, parameter :: n_OUT = n_IN + 2
     integer, parameter :: n_DAT = n_IN + 3
-    integer :: i, j, num_seeds
+    integer :: i, j
     type(random_samples_t), allocatable :: samples(:)
 
     ! Inputs
@@ -51,9 +51,6 @@
     ! Body of miniFAVOR
 
     !Get input file name
-    call random_seed(size=num_seeds)
-    call random_seed(put=[(i, i=1, num_seeds)])
-
     print *, 'Input file name:'
     read (*,'(a)') fn_IN
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(minifav
   I_O.f90
   random_samples_m.f90
   random_samples_s.f90
+  material_content_m.f90
+  material_content_s.f90
 )
 target_link_libraries(minifav
   PRIVATE sourcery

--- a/src/Calc_RTndt.f90
+++ b/src/Calc_RTndt.f90
@@ -31,7 +31,6 @@ implicit none
         !Variables
         real :: CF
         real, intent(in) :: Cu, Ni
-        real :: CF_1, CF_2
 
         ! Calculate interpolation coefficients for copper/nickel percentages:
         ! Truncate copper/nickel percentages to ranges [0%, 0.40%] and [0%, 1.2%], respectively.
@@ -56,12 +55,13 @@ implicit none
                   CF = CF_weld(Cu_int, Ni_int) + &
                   (Cu-0.01*(Cu_int))/0.01 * (CF_weld(Cu_int+1,Ni_int)-CF_weld(Cu_int+1,Ni_int))
               case default
-                  CF_1 = CF_weld(Cu_int,Ni_int) + &
-                      (Cu-0.01*(Cu_int))/0.01 * (CF_weld(Cu_int+1,Ni_int)-CF_weld(Cu_int+1,Ni_int))
-                  CF_2 = CF_weld(Cu_int,Ni_int+1) + &
-                      (Cu-0.01*(Cu_int))/0.01 * (CF_weld(Cu_int+1,Ni_int+1)-CF_weld(Cu_int+1,Ni_int+1))
-              !Second, interpolate on nickel
-              CF = CF_1 + (Ni-0.2*(Ni_int-1))/0.2 * (CF_2-CF_1)
+          associate( &
+            CF_1 => CF_weld(Cu_int,Ni_int) + (Cu-0.01*(Cu_int))/0.01 * (CF_weld(Cu_int+1,Ni_int)-CF_weld(Cu_int+1,Ni_int)), &
+            CF_2 => CF_weld(Cu_int,Ni_int+1) + (Cu-0.01*(Cu_int))/0.01 * (CF_weld(Cu_int+1,Ni_int+1)-CF_weld(Cu_int+1,Ni_int+1)) &
+          )
+            !Second, interpolate on nickel
+            CF = CF_1 + (Ni-0.2*(Ni_int-1))/0.2 * (CF_2-CF_1)
+          end associate
               end select
           end if
         end associate

--- a/src/Calc_RTndt.f90
+++ b/src/Calc_RTndt.f90
@@ -1,5 +1,6 @@
 module calc_RTndt
   use assertions_interface, only : assert
+  use material_content_m, only : material_content_t
 
 implicit none
 
@@ -86,14 +87,15 @@ implicit none
 
     !This subroutine samples the copper and nickel contents based on the nominal value
     !and the standard deviation
-    subroutine sample_chem(Cu_ave, Ni_ave, Cu_sig, Ni_sig, Cu_local, Ni_local, samples)
+    pure function sample_chem(Cu_ave, Ni_ave, Cu_sig, Ni_sig, samples) result(material_content)
         use randomness_m, only : random_samples_t
 
         !Variables
         type(random_samples_t), intent(in) :: samples
         real, intent(in) :: Cu_ave, Ni_ave, Cu_sig, Ni_sig
-        real, intent(out) :: Cu_local, Ni_local
+        real :: Cu_local, Ni_local
         real :: Cu_bar, Cu_sig_star, Cu_sig_local
+        type(material_content_t) material_content
 
         ! Requires
         call assert(samples%user_defined(), "random_samples_t%sample_chem: samples%user_defined()")
@@ -107,6 +109,8 @@ implicit none
         !Sample local nickel content based on weld nickel heat 34B009 & W5214 procedure
         Ni_local = Ni_ave + Ni_sig*sqrt(2.0)*erfc(2*samples%Ni_local()-1)
 
-    end subroutine sample_chem
+        material_content = material_content_t(Cu=Cu_local, Ni=Ni_local)
+
+    end function sample_chem
 
 end module calc_RTndt

--- a/src/Calc_RTndt.f90
+++ b/src/Calc_RTndt.f90
@@ -31,55 +31,64 @@ implicit none
         !Variables
         real :: CF
         real, intent(in) :: Cu, Ni
-        integer :: Cu_int, Ni_int
         real :: CF_1, CF_2
 
-        !Calculate indexes for copper interpolation:
-        !  multiply the Cu-% by 100 and take the integer truncation to find interpolation bounds
-        !  truncate interpolation between 0% and 0.40%
-        Cu_int = int(Cu*100)
-        if (Cu_int < 0) then
-            Cu_int = 0
-        else if (Cu_int > 40) then
-            Cu_int = 40
-        end if
+        ! Calculate interpolation coefficients for copper/nickel percentages:
+        ! Truncate copper/nickel percentages to ranges [0%, 0.40%] and [0%, 1.2%], respectively.
+        associate( &
+          Cu_int => rounded_and_bounded(Cu*100, bounds=[0, 40]), &
+          Ni_int => int(rounded_and_bounded(Ni*100, bounds=[0, 120])/20) + 1 &
+          ! Nickel contents in CF_weld are at intervals of 0.20% nickel
+        )
+          !Bi-linear interpolation
+          if (Cu <= 0.0 .or. Cu >= 0.40) then !only interpolate on nickel
+              select case (Ni_int)
+              case (7)
+                  CF = CF_weld(Cu_int, Ni_int)
+              case default
+                  CF = CF_weld(Cu_int,Ni_int) + &
+                  (Ni-0.2*(Ni_int-1))/0.2 * (CF_weld(Cu_int,Ni_int+1)-CF_weld(Cu_int,Ni_int))
+              end select
+          else
+              !First, interpolate on copper
+              select case (Ni_int)
+              case (7)
+                  CF = CF_weld(Cu_int, Ni_int) + &
+                  (Cu-0.01*(Cu_int))/0.01 * (CF_weld(Cu_int+1,Ni_int)-CF_weld(Cu_int+1,Ni_int))
+              case default
+                  CF_1 = CF_weld(Cu_int,Ni_int) + &
+                      (Cu-0.01*(Cu_int))/0.01 * (CF_weld(Cu_int+1,Ni_int)-CF_weld(Cu_int+1,Ni_int))
+                  CF_2 = CF_weld(Cu_int,Ni_int+1) + &
+                      (Cu-0.01*(Cu_int))/0.01 * (CF_weld(Cu_int+1,Ni_int+1)-CF_weld(Cu_int+1,Ni_int+1))
+              !Second, interpolate on nickel
+              CF = CF_1 + (Ni-0.2*(Ni_int-1))/0.2 * (CF_2-CF_1)
+              end select
+          end if
+        end associate
 
-        !Calculate indexes for nickel interpolation:
-        !  multiply the Ni-% by 100 and take the integer truncation to find interpolation bounds
-        !  truncate interpolation between 0% and 1.20%
-        Ni_int = int(Ni*100)
-        if (Ni_int < 0) then
-            Ni_int = 0
-        else if (Ni_int > 120) then
-            Ni_int = 120
-        end if
-        !Nickel contents in CF_weld are at intervals of 0.20% nickel
-        Ni_int = int(Ni_int/20)+1
+    contains
 
-        !Bi-linear interpolation
-        if (Cu <= 0.0 .or. Cu >= 0.40) then !only interpolate on nickel
-            select case (Ni_int)
-            case (7)
-                CF = CF_weld(Cu_int, Ni_int)
-            case default
-                CF = CF_weld(Cu_int,Ni_int) + &
-                (Ni-0.2*(Ni_int-1))/0.2 * (CF_weld(Cu_int,Ni_int+1)-CF_weld(Cu_int,Ni_int))
-            end select
-        else
-            !First, interpolate on copper
-            select case (Ni_int)
-            case (7)
-                CF = CF_weld(Cu_int, Ni_int) + &
-                (Cu-0.01*(Cu_int))/0.01 * (CF_weld(Cu_int+1,Ni_int)-CF_weld(Cu_int+1,Ni_int))
-            case default
-                CF_1 = CF_weld(Cu_int,Ni_int) + &
-                    (Cu-0.01*(Cu_int))/0.01 * (CF_weld(Cu_int+1,Ni_int)-CF_weld(Cu_int+1,Ni_int))
-                CF_2 = CF_weld(Cu_int,Ni_int+1) + &
-                    (Cu-0.01*(Cu_int))/0.01 * (CF_weld(Cu_int+1,Ni_int+1)-CF_weld(Cu_int+1,Ni_int+1))
-            !Second, interpolate on nickel
-            CF = CF_1 + (Ni-0.2*(Ni_int-1))/0.2 * (CF_2-CF_1)
-            end select
-        end if
+      pure function rounded_and_bounded(unbounded_value, bounds)
+        integer rounded_and_bounded
+        real, intent(in) :: unbounded_value
+        integer, intent(in) :: bounds(:)
+        integer, parameter :: end_points=2
+
+        call assert(size(bounds)==end_points, "Calc_RTndt|bounded_value: size(bounds)==end_points")
+
+        associate(floor_=>bounds(1), ceiling_=>bounds(2))
+
+          if (unbounded_value < floor_) then
+            rounded_and_bounded = floor_
+          else if (unbounded_value > ceiling_) then
+            rounded_and_bounded  = ceiling_
+          else
+            rounded_and_bounded = int(unbounded_value)
+          end if
+
+        end associate
+
+      end function
 
     end function CF
 

--- a/src/Calc_RTndt.f90
+++ b/src/Calc_RTndt.f90
@@ -2,59 +2,58 @@ module calc_RTndt
   use assertions_interface, only : assert
   use material_content_m, only : material_content_t
 
-implicit none
+  implicit none
 
-    contains
+contains
 
-    pure function RTndt(a, CF, fsurf, RTndt0, phi)
+  pure function RTndt(a, CF, fsurf, RTndt0, phi)
 
-        real :: RTndt
-        real, intent(in) :: a, CF, fsurf, RTndt0, phi
+    real :: RTndt
+    real, intent(in) :: a, CF, fsurf, RTndt0, phi
 
-        associate( &
-          D_RTepi => -29.5+78.0*(-log(1-phi))**(1/1.73), &
-          f => fsurf*exp(-0.24*a) &
-        )
-          associate(D_RTndt => CF*f**(0.28-0.10*log10(f)))
+    associate( &
+      D_RTepi => -29.5+78.0*(-log(1-phi))**(1/1.73), &
+      f => fsurf*exp(-0.24*a) &
+    )
+      associate(D_RTndt => CF*f**(0.28-0.10*log10(f)))
+        RTndt = RTndt0 + D_RTepi + D_RTndt
+      end associate
+    end associate
 
-          RTndt = RTndt0 + D_RTepi + D_RTndt
-       end associate
-       end associate
+  end function RTndt
 
-    end function RTndt
+  !This function calculates the weld chemistry factor given the copper and nickel contents
+  pure function CF(Cu, Ni)
 
-    !This function calculates the weld chemistry factor given the copper and nickel contents
-    pure function CF(Cu, Ni)
+    use constants_h, only: CF_weld
 
-        use constants_h, only: CF_weld
+    !Variables
+    real :: CF
+    real, intent(in) :: Cu, Ni
 
-        !Variables
-        real :: CF
-        real, intent(in) :: Cu, Ni
-
-        ! Calculate interpolation coefficients for copper/nickel percentages:
-        ! Truncate copper/nickel percentages to ranges [0%, 0.40%] and [0%, 1.2%], respectively.
-        associate( &
-          Cu_int => rounded_and_bounded(Cu*100, bounds=[0, 40]), &
-          Ni_int => int(rounded_and_bounded(Ni*100, bounds=[0, 120])/20) + 1 &
-          ! Nickel contents in CF_weld are at intervals of 0.20% nickel
-        )
-          !Bi-linear interpolation
-          if (Cu <= 0.0 .or. Cu >= 0.40) then !only interpolate on nickel
-              select case (Ni_int)
-              case (7)
-                  CF = CF_weld(Cu_int, Ni_int)
-              case default
-                  CF = CF_weld(Cu_int,Ni_int) + &
-                  (Ni-0.2*(Ni_int-1))/0.2 * (CF_weld(Cu_int,Ni_int+1)-CF_weld(Cu_int,Ni_int))
-              end select
-          else
-              !First, interpolate on copper
-              select case (Ni_int)
-              case (7)
-                  CF = CF_weld(Cu_int, Ni_int) + &
-                  (Cu-0.01*(Cu_int))/0.01 * (CF_weld(Cu_int+1,Ni_int)-CF_weld(Cu_int+1,Ni_int))
-              case default
+    ! Calculate interpolation coefficients for copper/nickel percentages:
+    ! Truncate copper/nickel percentages to ranges [0%, 0.40%] and [0%, 1.2%], respectively.
+    associate( &
+      Cu_int => rounded_and_bounded(Cu*100, bounds=[0, 40]), &
+      Ni_int => int(rounded_and_bounded(Ni*100, bounds=[0, 120])/20) + 1 &
+      ! Nickel contents in CF_weld are at intervals of 0.20% nickel
+    )
+      !Bi-linear interpolation
+      if (Cu <= 0.0 .or. Cu >= 0.40) then !only interpolate on nickel
+        select case (Ni_int)
+        case (7)
+            CF = CF_weld(Cu_int, Ni_int)
+        case default
+            CF = CF_weld(Cu_int,Ni_int) + &
+            (Ni-0.2*(Ni_int-1))/0.2 * (CF_weld(Cu_int,Ni_int+1)-CF_weld(Cu_int,Ni_int))
+        end select
+      else
+        !First, interpolate on copper
+        select case (Ni_int)
+        case (7)
+          CF = CF_weld(Cu_int, Ni_int) + &
+          (Cu-0.01*(Cu_int))/0.01 * (CF_weld(Cu_int+1,Ni_int)-CF_weld(Cu_int+1,Ni_int))
+        case default
           associate( &
             CF_1 => CF_weld(Cu_int,Ni_int) + (Cu-0.01*(Cu_int))/0.01 * (CF_weld(Cu_int+1,Ni_int)-CF_weld(Cu_int+1,Ni_int)), &
             CF_2 => CF_weld(Cu_int,Ni_int+1) + (Cu-0.01*(Cu_int))/0.01 * (CF_weld(Cu_int+1,Ni_int+1)-CF_weld(Cu_int+1,Ni_int+1)) &
@@ -62,65 +61,65 @@ implicit none
             !Second, interpolate on nickel
             CF = CF_1 + (Ni-0.2*(Ni_int-1))/0.2 * (CF_2-CF_1)
           end associate
-              end select
-          end if
-        end associate
+        end select
+      end if
+    end associate
 
-    contains
+  contains
 
-      pure function rounded_and_bounded(unbounded_value, bounds)
-        integer rounded_and_bounded
-        real, intent(in) :: unbounded_value
-        integer, intent(in) :: bounds(:)
-        integer, parameter :: end_points=2
+    pure function rounded_and_bounded(unbounded_value, bounds)
+      integer rounded_and_bounded
+      real, intent(in) :: unbounded_value
+      integer, intent(in) :: bounds(:)
+      integer, parameter :: end_points=2
 
-        call assert(size(bounds)==end_points, "Calc_RTndt|bounded_value: size(bounds)==end_points")
+      call assert(size(bounds)==end_points, "Calc_RTndt|bounded_value: size(bounds)==end_points")
 
-        associate(floor_=>bounds(1), ceiling_=>bounds(2))
+      associate(floor_=>bounds(1), ceiling_=>bounds(2))
 
-          if (unbounded_value < floor_) then
-            rounded_and_bounded = floor_
-          else if (unbounded_value > ceiling_) then
-            rounded_and_bounded  = ceiling_
-          else
-            rounded_and_bounded = int(unbounded_value)
-          end if
+        if (unbounded_value < floor_) then
+          rounded_and_bounded = floor_
+        else if (unbounded_value > ceiling_) then
+          rounded_and_bounded  = ceiling_
+        else
+          rounded_and_bounded = int(unbounded_value)
+        end if
 
-        end associate
+      end associate
 
-      end function
+    end function
 
-    end function CF
+  end function CF
 
-    !This subroutine samples the copper and nickel contents based on the nominal value
-    !and the standard deviation
-    pure function sample_chem(Cu_ave, Ni_ave, Cu_sig, Ni_sig, samples) result(material_content)
-        use randomness_m, only : random_samples_t
+  !This subroutine samples the copper and nickel contents based on the nominal value
+  !and the standard deviation
+  pure function sample_chem(Cu_ave, Ni_ave, Cu_sig, Ni_sig, samples) result(material_content)
+    use randomness_m, only : random_samples_t
 
-        !Variables
-        type(random_samples_t), intent(in) :: samples
-        real, intent(in) :: Cu_ave, Ni_ave, Cu_sig, Ni_sig
-        type(material_content_t) material_content
+    !Variables
+    type(random_samples_t), intent(in) :: samples
+    real, intent(in) :: Cu_ave, Ni_ave, Cu_sig, Ni_sig
+    type(material_content_t) material_content
 
-        ! Requires
-        call assert(samples%user_defined(), "random_samples_t%sample_chem: samples%user_defined()")
+    ! Requires
+    call assert(samples%user_defined(), "random_samples_t%sample_chem: samples%user_defined()")
 
+    associate( &
+      Cu_bar => Cu_ave * Cu_sig, &
+      Cu_sig_star => min(0.0718*Cu_ave, 0.0185) &
+    )
+     !Sample local copper content based on weld copper sampling procedure
+      associate(Cu_sig_local => Cu_bar + Cu_sig_star*sqrt(2.0)*erfc(2*samples%Cu_sig_local()-1))
+        !Sample local nickel content based on weld nickel heat 34B009 & W5214 procedure
         associate( &
-          Cu_bar => Cu_ave * Cu_sig, &
-          Cu_sig_star => min(0.0718*Cu_ave, 0.0185) &
+          Cu_local => Cu_ave + Cu_sig_local*sqrt(2.0)*erfc(2*samples%Cu_local()-1), &
+          Ni_local => Ni_ave + Ni_sig*sqrt(2.0)*erfc(2*samples%Ni_local()-1) &
         )
-         !Sample local copper content based on weld copper sampling procedure
-          associate(Cu_sig_local => Cu_bar + Cu_sig_star*sqrt(2.0)*erfc(2*samples%Cu_sig_local()-1))
-            !Sample local nickel content based on weld nickel heat 34B009 & W5214 procedure
-            associate( &
-              Cu_local => Cu_ave + Cu_sig_local*sqrt(2.0)*erfc(2*samples%Cu_local()-1), &
-              Ni_local => Ni_ave + Ni_sig*sqrt(2.0)*erfc(2*samples%Ni_local()-1))
-
-              material_content = material_content_t(Cu=Cu_local, Ni=Ni_local)
-            end associate
-          end associate
+          material_content = material_content_t(Cu=Cu_local, Ni=Ni_local)
         end associate
+      end associate
+    end associate
 
-    end function sample_chem
+  end function sample_chem
 
 end module calc_RTndt

--- a/src/Calc_RTndt.f90
+++ b/src/Calc_RTndt.f90
@@ -6,7 +6,7 @@ implicit none
     contains
 
     !RTndt_x calculation
-    function RTndt(a, CF, fsurf, RTndt0, phi)
+    pure function RTndt(a, CF, fsurf, RTndt0, phi)
 
         !Variables
         real :: RTndt, D_RTepi, D_RTndt, f
@@ -25,7 +25,7 @@ implicit none
     end function RTndt
 
     !This function calculates the weld chemistry factor given the copper and nickel contents
-    function CF(Cu, Ni)
+    pure function CF(Cu, Ni)
 
         use constants_h, only: CF_weld
 

--- a/src/Calc_RTndt.f90
+++ b/src/Calc_RTndt.f90
@@ -6,22 +6,20 @@ implicit none
 
     contains
 
-    !RTndt_x calculation
     pure function RTndt(a, CF, fsurf, RTndt0, phi)
 
-        !Variables
-        real :: RTndt, D_RTepi, D_RTndt, f
+        real :: RTndt
         real, intent(in) :: a, CF, fsurf, RTndt0, phi
 
-        !Calculate D_RTepi
-        D_RTepi = -29.5+78.0*(-log(1-phi))**(1/1.73)
+        associate( &
+          D_RTepi => -29.5+78.0*(-log(1-phi))**(1/1.73), &
+          f => fsurf*exp(-0.24*a) &
+        )
+          associate(D_RTndt => CF*f**(0.28-0.10*log10(f)))
 
-        !Calculate D_RTndt
-        f = fsurf*exp(-0.24*a)
-        D_RTndt = CF*f**(0.28-0.10*log10(f))
-
-        !Calculate the RTndt
-        RTndt = RTndt0 + D_RTepi + D_RTndt
+          RTndt = RTndt0 + D_RTepi + D_RTndt
+       end associate
+       end associate
 
     end function RTndt
 

--- a/src/Calc_cpi.f90
+++ b/src/Calc_cpi.f90
@@ -1,29 +1,29 @@
 module calc_cpi
-    
-implicit none
-    
-    contains
-        
-    !Function to calculate cpi(t)
-    pure function cpi_t(K, RTndt, T)
-            
-        !Variables
-        real :: cpi_t
-        real, intent(in) :: K, RTndt, T
-        real :: aKic, bKic, cKic
-            
-        !Calculate aKic, bKic, cKic
-        aKic = 19.35+8.335*exp(0.02254*(T-RTndt))
-        bKic = 15.61+50.132*exp(0.008*(T-RTndt))
-        cKic = 4.0
-            
-        !Calculate cpi_t
-        if (K < aKic) then
-            cpi_t = 0.0
-        else
-            cpi_t = 1-exp(-((K-aKic)/bKic)**cKic)
-        end if
-            
-    end function cpi_t
-        
+
+  implicit none
+
+ contains
+
+  !Function to calculate cpi(t)
+  pure function cpi_t(K, RTndt, T)
+
+    !Variables
+    real :: cpi_t
+    real, intent(in) :: K, RTndt, T
+    real :: aKic, bKic, cKic
+
+    !Calculate aKic, bKic, cKic
+    aKic = 19.35+8.335*exp(0.02254*(T-RTndt))
+    bKic = 15.61+50.132*exp(0.008*(T-RTndt))
+    cKic = 4.0
+
+    !Calculate cpi_t
+    if (K < aKic) then
+        cpi_t = 0.0
+    else
+        cpi_t = 1-exp(-((K-aKic)/bKic)**cKic)
+    end if
+
+  end function cpi_t
+
 end module calc_cpi

--- a/src/Calc_cpi.f90
+++ b/src/Calc_cpi.f90
@@ -10,15 +10,16 @@ module calc_cpi
     !Variables
     real :: cpi_t
     real, intent(in) :: K, RTndt, T
-    real :: aKic, bKic, cKic
+    real, parameter :: cKic = 4.0
 
     !Calculate aKic, bKic, cKic
-    aKic = 19.35+8.335*exp(0.02254*(T-RTndt))
-    bKic = 15.61+50.132*exp(0.008*(T-RTndt))
-    cKic = 4.0
-
+    associate( &
+      aKic => 19.35+8.335*exp(0.02254*(T-RTndt)), &
+      bKic => 15.61+50.132*exp(0.008*(T-RTndt)) &
+    )
     !Calculate cpi_t
-    cpi_t = merge(0.0,1-exp(-((K-aKic)/bKic)**cKic), K < aKic)
+      cpi_t = merge(0.0,1-exp(-((K-aKic)/bKic)**cKic), K < aKic)
+    end associate
 
   end function cpi_t
 

--- a/src/Calc_cpi.f90
+++ b/src/Calc_cpi.f90
@@ -4,20 +4,17 @@ module calc_cpi
 
  contains
 
-  !Function to calculate cpi(t)
+  ! calculate cpi(t)
   pure function cpi_t(K, RTndt, T)
 
-    !Variables
     real :: cpi_t
     real, intent(in) :: K, RTndt, T
     real, parameter :: cKic = 4.0
 
-    !Calculate aKic, bKic, cKic
     associate( &
       aKic => 19.35+8.335*exp(0.02254*(T-RTndt)), &
       bKic => 15.61+50.132*exp(0.008*(T-RTndt)) &
     )
-    !Calculate cpi_t
       cpi_t = merge(0.0,1-exp(-((K-aKic)/bKic)**cKic), K < aKic)
     end associate
 

--- a/src/Calc_cpi.f90
+++ b/src/Calc_cpi.f90
@@ -5,7 +5,7 @@ implicit none
     contains
         
     !Function to calculate cpi(t)
-    function cpi_t(K, RTndt, T)
+    pure function cpi_t(K, RTndt, T)
             
         !Variables
         real :: cpi_t

--- a/src/Calc_cpi.f90
+++ b/src/Calc_cpi.f90
@@ -2,7 +2,7 @@ module calc_cpi
 
   implicit none
 
- contains
+contains
 
   ! calculate cpi(t)
   pure function cpi_t(K, RTndt, T)

--- a/src/Calc_cpi.f90
+++ b/src/Calc_cpi.f90
@@ -18,11 +18,7 @@ module calc_cpi
     cKic = 4.0
 
     !Calculate cpi_t
-    if (K < aKic) then
-        cpi_t = 0.0
-    else
-        cpi_t = 1-exp(-((K-aKic)/bKic)**cKic)
-    end if
+    cpi_t = merge(0.0,1-exp(-((K-aKic)/bKic)**cKic), K < aKic)
 
   end function cpi_t
 

--- a/src/material_content_m.f90
+++ b/src/material_content_m.f90
@@ -1,0 +1,53 @@
+module material_content_m
+  implicit none
+
+  private
+  public :: material_content_t
+
+  type material_content_t
+    !! Elemental content
+    private
+    real Cu_ !! copper
+    real Ni_ !! nickel
+  contains
+    procedure :: Cu
+    procedure :: Ni
+  end type
+
+  interface material_content_t
+
+    pure module function user_define(Cu, Ni) result(new_material_content_t)
+      !! Define new material_content_t
+      implicit none
+      real, intent(in) :: Cu !! copper
+      real, intent(in) :: Ni !! nickel
+      type(material_content_t) new_material_content_t
+    end function
+
+  end interface
+
+  interface
+
+    module subroutine write_formatted(self, unit, iotype, v_list, iostat, iomsg)
+      implicit none
+      class(material_content_t), intent(in) :: self
+      integer, intent(in) :: unit
+      character(*), intent(in) :: iotype
+      integer, intent(in) :: v_list(:)
+      integer, intent(out) :: iostat
+      character(*), intent(inout) :: iomsg
+    end subroutine
+
+    pure module function Cu(self) result(my_Cu)
+      class(material_content_t), intent(in) :: self
+      real my_Cu
+    end function
+
+    pure module function Ni(self) result(my_Ni)
+      class(material_content_t), intent(in) :: self
+      real my_Ni
+    end function
+
+  end interface
+
+end module

--- a/src/material_content_m.f90
+++ b/src/material_content_m.f90
@@ -38,12 +38,12 @@ module material_content_m
       character(*), intent(inout) :: iomsg
     end subroutine
 
-    pure module function Cu(self) result(my_Cu)
+    elemental module function Cu(self) result(my_Cu)
       class(material_content_t), intent(in) :: self
       real my_Cu
     end function
 
-    pure module function Ni(self) result(my_Ni)
+    elemental module function Ni(self) result(my_Ni)
       class(material_content_t), intent(in) :: self
       real my_Ni
     end function

--- a/src/material_content_s.f90
+++ b/src/material_content_s.f90
@@ -1,0 +1,39 @@
+submodule(material_content_m) material_content_s
+  use assertions_interface, only : assert
+  implicit none
+
+contains
+
+  module procedure write_formatted
+    integer, parameter :: success=0
+
+    select case(iotype)
+    case('LISTDIRECTED')
+      write(unit,*) "material_local_t(Cu_=", self%Cu_, ", Ni_=", self%Ni_, ")"
+      iostat = success
+    case default
+      block
+        use iso_fortran_env, only : IOSTAT_INQUIRE_INTERNAL_UNIT
+        integer, parameter :: iotype_not_supported=99
+        call assert(iotype_not_supported/=IOSTAT_INQUIRE_INTERNAL_UNIT, "standard-conforming iostat_value")
+        iostat = iotype_not_supported
+        iomsg = "iotype not supported"
+      end block
+    end select
+
+  end procedure
+
+  module procedure user_define
+     new_material_content_t%Cu_ = Cu
+     new_material_content_t%Ni_ = Ni
+  end procedure
+
+  module procedure Cu
+     my_Cu = self%Cu_
+  end procedure
+
+  module procedure Ni
+     my_Ni = self%Ni_
+  end procedure
+
+end submodule

--- a/src/random_samples_s.f90
+++ b/src/random_samples_s.f90
@@ -5,11 +5,23 @@ submodule(randomness_m) randomness_s
 contains
 
   module procedure define
+    logical, save :: first_call=.true.
+
+    if (first_call) then
+      first_call=.false.
+      block
+        integer i, num_seeds
+        call random_seed(size=num_seeds)
+        call random_seed(put=[(i, i=1, num_seeds)])
+      end block
+    end if
+
     ! These must be called in this order or the results will change
     call random_number(self%Cu_sig_local_)
     call random_number(self%Cu_local_)
     call random_number(self%Ni_local_)
     call random_number(self%phi_)
+
     call self%mark_as_defined
   end procedure
 


### PR DESCRIPTION
1. The refactored `sample_chem` function result is a
    `material_content_t` object defined to encapsulate the previous
    sample_chem subroutine's two `intent(out)` array arguments.
2. To maintain the pre-existing `write_OUT` subroutine interface,
    the `material_content_t` getter functions are `elemental` and
    are used to assemble array arguments for `write_OUT`.