### PR TITLE
WIP (Do Not Merge): Data parallelism

### DIFF
--- a/app/miniFAVOR.f90
+++ b/app/miniFAVOR.f90
@@ -19,7 +19,6 @@
     use calc_cpi, only : cpi_t
     use random_samples_m, only: random_samples_t
     use material_content_m, only: material_content_t
-    use data_partition_interface, only : data_partition_t => data_partition
     use input_data_m, only : input_data_t
     use output_data_m, only : output_data_t
     use detailed_output_m, only : detailed_output_t
@@ -32,9 +31,7 @@
     integer, parameter :: input_unit_reader=1, output_writer=1
     integer :: i
     type(random_samples_t), allocatable :: samples(:)
-    type(data_partition_t) data_partition
     type(input_data_t) input_data
-
 
     ! Body of miniFAVOR
 
@@ -51,11 +48,7 @@
       call input_data%broadcast(source_image = input_unit_reader)
 
       !Calculate applied stress intensity factor (SIF)
-      associate( &
-        nsim => input_data%nsim() &
-      )
-
-        call data_partition%define_partitions(cardinality=nsim)
+      associate(nsim => input_data%nsim())
 
         allocate(samples(nsim))
         do i = 1, nsim ! This cannot be parallelized or reordered without the results changing
@@ -68,7 +61,7 @@
         )
           if (me==output_writer) then
             block
-              integer :: unit
+              integer unit
 
               open(newunit=unit,  file=base_name//".out", status='unknown')
               write(unit, '(DT)') output_data

--- a/app/miniFAVOR.f90
+++ b/app/miniFAVOR.f90
@@ -14,11 +14,11 @@
 
     program miniFAVOR
 
+    use assertions_interface, only : assert
     use calc_RTndt, only : RTndt, CF
     use calc_K, only : Ki_t
     use calc_cpi, only : cpi_t
     use random_samples_m, only: random_samples_t
-    use material_content_m, only: material_content_t
     use input_data_m, only : input_data_t
     use output_data_m, only : output_data_t
     use detailed_output_m, only : detailed_output_t
@@ -49,6 +49,8 @@
 
       !Calculate applied stress intensity factor (SIF)
       associate(nsim => input_data%nsim())
+
+        call assert(nsim>0, "main: nsim>0", nsim)
 
         allocate(samples(nsim))
         do i = 1, nsim ! This cannot be parallelized or reordered without the results changing

--- a/src/input_data_s.f90
+++ b/src/input_data_s.f90
@@ -107,7 +107,6 @@ contains
     module procedure broadcast
 
       integer size_stress, size_temp
-      type(input_data_t) message ! work around gfortran lack of support for polymorphic co_broadcast argument
 
       associate(me => this_image())
 
@@ -119,18 +118,49 @@ contains
         call co_broadcast(size_stress, source_image)
         call co_broadcast(size_temp, source_image)
 
-        if (me == source_image) then
-          message = self
-        else
-          allocate(message%stress_(size_stress))
-          allocate(message%temp_(size_temp))
+        if (me /= source_image) then
+          allocate(self%stress_(size_stress))
+          allocate(self%temp_(size_temp))
         end if
+       end associate
 
-        call co_broadcast(message, source_image)
+       workarounds: &
+       block
 
-        if (me /= source_image) self = message
+         logical, parameter :: opencoarrays_issue_727_fixed = .false.
 
-      end associate
+         if (.not. opencoarrays_issue_727_fixed) then
+          ! work around OpenCoarrays issue 727 (https://github.com/sourceryinstitute/OpenCoarrays/issues/727)
+          call broadcast_components
+         else
+           select type(self)
+             ! work around gfortran lack of support for polymorphic co_broadcast argument
+             type is(input_data_t)
+               call co_broadcast(self, source_image)
+             class default
+               error stop "input_data_type_t%broadcast: unsupported type"
+           end select
+         end if
+
+       end block workarounds
+
+    contains
+
+      subroutine broadcast_components()
+        call co_broadcast(self%a_, source_image)
+        call co_broadcast(self%b_, source_image)
+        call co_broadcast(self%Cu_ave_, source_image)
+        call co_broadcast(self%Ni_ave_, source_image)
+        call co_broadcast(self%Cu_sig_, source_image)
+        call co_broadcast(self%Ni_sig_, source_image)
+        call co_broadcast(self%fsurf_, source_image)
+        call co_broadcast(self%RTndt0_, source_image)
+        call co_broadcast(self%stress_, source_image)
+        call co_broadcast(self%temp_, source_image)
+        call co_broadcast(self%nsim_, source_image)
+        call co_broadcast(self%ntime_, source_image)
+        call co_broadcast(self%details_, source_image)
+      end subroutine
 
     end procedure
 

--- a/src/material_content_m.f90
+++ b/src/material_content_m.f90
@@ -41,11 +41,13 @@ module material_content_m
     end subroutine
 
     elemental module function Cu(self) result(my_Cu)
+      implicit none
       class(material_content_t), intent(in) :: self
       real my_Cu
     end function
 
     elemental module function Ni(self) result(my_Ni)
+      implicit none
       class(material_content_t), intent(in) :: self
       real my_Ni
     end function

--- a/src/material_content_m.f90
+++ b/src/material_content_m.f90
@@ -1,8 +1,10 @@
 module material_content_m
+  use data_partition_interface, only : data_partition_t
   implicit none
 
   private
   public :: material_content_t
+  public :: gather
 
   type material_content_t
     !! Elemental content
@@ -51,6 +53,13 @@ module material_content_m
       class(material_content_t), intent(in) :: self
       real my_Ni
     end function
+
+    module subroutine gather(material_content, data_partition, dim)
+      implicit none
+      type(material_content_t), intent(inout) :: material_content(:)
+      type(data_partition_t), intent(in) :: data_partition
+      integer, optional :: dim
+    end subroutine
 
   end interface
 

--- a/src/material_content_s.f90
+++ b/src/material_content_s.f90
@@ -53,4 +53,25 @@ contains
 
   end procedure
 
+  module procedure gather
+
+    real, allocatable, dimension(:) :: Cu_local, Ni_local
+
+    allocate(Cu_local(size(material_content)), Ni_local(size(material_content)))
+
+    associate(me => this_image())
+      associate(my_first => data_partition%first(me), my_last => data_partition%last(me))
+        Cu_local(my_first:my_last) = material_content(my_first:my_last)%Cu()
+        Ni_local(my_first:my_last) = material_content(my_first:my_last)%Ni()
+      end associate
+    end associate
+
+    call data_partition%gather(Cu_local, dim=1)
+    call data_partition%gather(Ni_local, dim=1)
+
+    material_content%Cu_ = Cu_local
+    material_content%Ni_ = Ni_local
+
+  end procedure
+
 end submodule

--- a/src/output_data_m.f90
+++ b/src/output_data_m.f90
@@ -32,16 +32,19 @@ module output_data_m
   interface output_data_t
 
     pure module function default_constructor() result(new_output_data_t)
+      implicit none
       type(output_data_t) new_output_data_t
     end function
 
     module function whole_shebang(input_data, random_samples) result(new_output_data)
+      implicit none
       type(input_data_t), intent(in) :: input_data
       type(random_samples_t), intent(in) :: random_samples(:)
       type(output_data_t) :: new_output_data
     end function
 
     pure module function new_output_data(input_data, R_Tndt, K_hist, Chemistry_content, Chemistry_factor, CPI, CPI_avg)
+      implicit none
       type(input_data_t), intent(in) :: input_data
       real, intent(in) :: R_Tndt(:)
       real, intent(in) :: K_hist(:), Chemistry_content(:,:), Chemistry_factor(:)

--- a/src/output_data_s.f90
+++ b/src/output_data_s.f90
@@ -19,14 +19,14 @@ contains
     use calc_RTndt, only : RTndt, CF
     use calc_K, only : Ki_t
     use calc_cpi, only : cpi_t
-    use material_content_m, only: material_content_t
+    use material_content_m, only: material_content_t, gather
     use data_partition_interface, only : data_partition_t
 
-    real, dimension(:,:), allocatable :: cpi_hist
     integer :: i, j
     type(data_partition_t) data_partition
+    type(material_content_t), allocatable :: material_content(:)
     real, allocatable :: CPI(:)
-    real, allocatable, dimension(:) :: R_Tndt, CPI, CPI_avg, Chemistry_factor, material_content
+    real, allocatable, dimension(:) :: R_Tndt, CPI_avg, Chemistry_factor
     real, allocatable, dimension(:,:) :: content
     integer, parameter :: nmaterials=2
 
@@ -36,9 +36,9 @@ contains
       ntime => input_data%ntime(), &
       me => this_image() &
     )
+      call assert(nsim>0, "whole_shebang: nsim>0", nsim)
 
-      allocate(R_Tndt(nsim), CPI(nsim), CPI_avg(nsim), Chemistry_factor(nsim), material_content(nsim))
-      allocate(content(nsim, nmaterials))
+      allocate(R_Tndt(nsim), CPI_avg(nsim), Chemistry_factor(nsim), material_content(nsim))
 
       call data_partition%define_partitions(cardinality=nsim)
 
@@ -56,38 +56,42 @@ contains
           input_data%a(), Chemistry_factor(my_first:my_last), input_data%fsurf(), input_data%RTndt0(), &
           random_samples(my_first:my_last)%phi() &
         )
+        block
+          real, dimension(:,:), allocatable :: cpi_hist
+
           !Start looping over number of simulations
           allocate(cpi_hist(my_first:my_last, ntime))
-          do concurrent(i = my_first:my_last, j = 1:ntime)
-            ! Instantaneous cpi(t)
-            associate(temp => input_data%temp())
-              cpi_hist(i,j) = cpi_t(K_hist(j), R_Tndt(i), temp(j))
-            end associate
+          do j = 1,ntime
+            do concurrent(i = my_first:my_last)
+              ! Instantaneous cpi(t)
+              associate(temp => input_data%temp())
+                cpi_hist(i,j) = cpi_t(K_hist(j), R_Tndt(i), temp(j))
+              end associate
+            end do
           end do
 
           allocate(CPI(nsim))
           CPI(my_first:my_last) = [(maxval(cpi_hist(i,:)), i=my_first,my_last)]
-          call data_partition%gather(CPI,dim=1)
+        end block
+        call data_partition%gather(CPI,dim=1)
 
-          ! Moving average CPI for all trials
-          CPI_avg = [(sum(CPI(1:i))/i, i=1,nsim)]
+        ! Moving average CPI for all trials
+        CPI_avg = [(sum(CPI(1:i))/i, i=1,nsim)]
 
-          call data_partition%gather(material_content, dim=1) !!!!! won't compile: we need a gather that supports derived types
+        call gather(material_content, data_partition, dim=1)
 
-          associate(content => reshape([material_content%Cu(),material_content%Ni()], [nsim, nmaterials] ))
+        content = reshape([material_content%Cu(),material_content%Ni()], [nsim, nmaterials] )
 
-            call data_partition%gather(R_tndt, dim=1)
-            call data_partition%gather(CPI, dim=1)
-            call data_partition%gather(CPI_avg, dim=1)
-            call data_partition%gather(content, dim=1)
-            call data_partition%gather(Chemistry_factor, dim=1)
+        call data_partition%gather(content, dim=1)
+        call data_partition%gather(R_tndt, dim=1)
+        call data_partition%gather(CPI, dim=1)
+        call data_partition%gather(CPI_avg, dim=1)
+        call data_partition%gather(Chemistry_factor, dim=1)
 
-            new_output_data = output_data_t( &
-                input_data=input_data, R_Tndt=R_Tndt, CPI=CPI, CPI_avg=CPI_avg, K_hist=K_hist, &
-                Chemistry_content=content, Chemistry_factor=Chemistry_factor &
-              )
-          end associate
-        end associate
+        new_output_data = output_data_t( &
+            input_data=input_data, R_Tndt=R_Tndt, CPI=CPI, CPI_avg=CPI_avg, K_hist=K_hist, &
+            Chemistry_content=content, Chemistry_factor=Chemistry_factor &
+          )
       end associate
     end associate
   end procedure

--- a/src/output_data_s.f90
+++ b/src/output_data_s.f90
@@ -20,47 +20,72 @@ contains
     use calc_K, only : Ki_t
     use calc_cpi, only : cpi_t
     use material_content_m, only: material_content_t
+    use data_partition_interface, only : data_partition_t
 
     real, dimension(:,:), allocatable :: cpi_hist
     integer :: i, j
+    type(data_partition_t) data_partition
+    real, allocatable :: CPI(:)
+    real, allocatable, dimension(:) :: R_Tndt, CPI, CPI_avg, Chemistry_factor, material_content
+    real, allocatable, dimension(:,:) :: content
+    integer, parameter :: nmaterials=2
 
     associate( &
       K_hist => Ki_t(input_data%a(), input_data%b(), input_data%stress()), &
       nsim => input_data%nsim(), &
-      ntime => input_data%ntime() &
+      ntime => input_data%ntime(), &
+      me => this_image() &
     )
 
-      !Sample chemistry: assign Cu content and Ni content
-      associate(material_content => material_content_t( &
-          input_data%Cu_ave(),  input_data%Ni_ave(), input_data%Cu_sig(), input_data%Ni_sig(), random_samples))
-        associate(Chemistry_factor => CF(material_content%Cu(), material_content%Ni()))
-          !Calculate RTndt for this vessel trial: CPI_results(i,1) is RTndt
-          associate(R_Tndt => RTndt( &
-              input_data%a(), Chemistry_factor, input_data%fsurf(), input_data%RTndt0(), random_samples%phi()) &
-          )
-            !Start looping over number of simulations
-            allocate(cpi_hist(nsim, ntime))
-            do concurrent(i = 1:nsim, j = 1:ntime)
-              ! Instantaneous cpi(t)
-              associate(temp => input_data%temp())
-                cpi_hist(i,j) = cpi_t(K_hist(j), R_Tndt(i), temp(j))
-              end associate
-            end do
-            associate(CPI => [(maxval(cpi_hist(i,:)), i=1,nsim)])
-              ! Moving average CPI for all trials
-              associate(CPI_avg => [(sum(CPI(1:i))/i, i=1,nsim)])
-                block
-                  integer, parameter :: nmaterials=2
+      allocate(R_Tndt(nsim), CPI(nsim), CPI_avg(nsim), Chemistry_factor(nsim), material_content(nsim))
+      allocate(content(nsim, nmaterials))
 
-                  associate(content => reshape([material_content%Cu(),material_content%Ni()], [nsim, nmaterials] ))
-                    new_output_data = output_data_t( &
-                        input_data=input_data, R_Tndt=R_Tndt, CPI=CPI, CPI_avg=CPI_avg, K_hist=K_hist, &
-                        Chemistry_content=content, Chemistry_factor=Chemistry_factor &
-                      )
-                  end associate
-                end block
-              end associate
+      call data_partition%define_partitions(cardinality=nsim)
+
+      associate(my_first => data_partition%first(me), my_last => data_partition%last(me))
+
+        !Sample chemistry: assign Cu content and Ni content
+        material_content(my_first:my_last) = material_content_t( &
+          input_data%Cu_ave(),  input_data%Ni_ave(), input_data%Cu_sig(), input_data%Ni_sig(), random_samples(my_first:my_last) &
+        )
+
+        Chemistry_factor(my_first:my_last) = CF(material_content(my_first:my_last)%Cu(), material_content(my_first:my_last)%Ni())
+
+        !Calculate RTndt for this vessel trial: CPI_results(i,1) is RTndt
+        R_Tndt(my_first:my_last) = RTndt( &
+          input_data%a(), Chemistry_factor(my_first:my_last), input_data%fsurf(), input_data%RTndt0(), &
+          random_samples(my_first:my_last)%phi() &
+        )
+          !Start looping over number of simulations
+          allocate(cpi_hist(my_first:my_last, ntime))
+          do concurrent(i = my_first:my_last, j = 1:ntime)
+            ! Instantaneous cpi(t)
+            associate(temp => input_data%temp())
+              cpi_hist(i,j) = cpi_t(K_hist(j), R_Tndt(i), temp(j))
             end associate
+          end do
+
+          allocate(CPI(nsim))
+          CPI(my_first:my_last) = [(maxval(cpi_hist(i,:)), i=my_first,my_last)]
+          call data_partition%gather(CPI,dim=1)
+
+          ! Moving average CPI for all trials
+          CPI_avg = [(sum(CPI(1:i))/i, i=1,nsim)]
+
+          call data_partition%gather(material_content, dim=1) !!!!! won't compile: we need a gather that supports derived types
+
+          associate(content => reshape([material_content%Cu(),material_content%Ni()], [nsim, nmaterials] ))
+
+            call data_partition%gather(R_tndt, dim=1)
+            call data_partition%gather(CPI, dim=1)
+            call data_partition%gather(CPI_avg, dim=1)
+            call data_partition%gather(content, dim=1)
+            call data_partition%gather(Chemistry_factor, dim=1)
+
+            new_output_data = output_data_t( &
+                input_data=input_data, R_Tndt=R_Tndt, CPI=CPI, CPI_avg=CPI_avg, K_hist=K_hist, &
+                Chemistry_content=content, Chemistry_factor=Chemistry_factor &
+              )
           end associate
         end associate
       end associate


### PR DESCRIPTION
This pull request contains a provisional sketch of the [data-parallel] programming pattern.
    
This implementation sketches an approach for using the Sourcery library's data_partition_t class to divide up the `nsim` simulations' data and work across the images and then have each image work only on its assigned simulations.

**This implementation sketch will not compile because it requires a `gather` type-bound procedure that works on a derived-type array.**  Currently, the supported gathers only work on intrinsic arrays.  A likely implementation will be type-specific and should therefore be written in the application code, analogous to the `broadcast` procedure that is current bound to the `input_data_t` type.

[data-parallel]: https://en.wikipedia.org/wiki/Data_parallelism